### PR TITLE
Added support for filtering for item title in the API.

### DIFF
--- a/backend/routes/api/items.js
+++ b/backend/routes/api/items.js
@@ -53,6 +53,10 @@ router.get("/", auth.optional, function(req, res, next) {
     query.tagList = { $in: [req.query.tag] };
   }
 
+  if (typeof req.query.title !== 'undefined') {
+    query.title = { $regex: req.query.title, $options: 'i' };
+  }
+
   Promise.all([
     req.query.seller ? User.findOne({ username: req.query.seller }) : null,
     req.query.favorited ? User.findOne({ username: req.query.favorited }) : null


### PR DESCRIPTION
Note that this new filter might not be very efficient when there are a lot of items.

# Description

As preparation for supporting search in our product, we added the ability to filter items by "title" in the "get items list" API.
This currently takes the title query and searches for it anywhere in the item titles, and it's case-insensitive.