### PR TITLE
Made the frontend app always get the backend URL from an environment variable

### DIFF
--- a/frontend/src/agent.js
+++ b/frontend/src/agent.js
@@ -3,10 +3,7 @@ import _superagent from "superagent";
 
 const superagent = superagentPromise(_superagent, global.Promise);
 
-const BACKEND_URL =
-  process.env.NODE_ENV !== "production"
-    ? process.env.REACT_APP_BACKEND_URL
-    : "https://api.anythink.market";
+const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
 
 const API_ROOT = `${BACKEND_URL}/api`;
 


### PR DESCRIPTION
Previously the backend URL was hardcoded in production, and in other stages the `REACT_APP_BACKEND_URL` env var was used.
We now use `REACT_APP_BACKEND_URL` in all stages including production.